### PR TITLE
Handling no sample data issue

### DIFF
--- a/corna/algorithms/background_correction.py
+++ b/corna/algorithms/background_correction.py
@@ -81,7 +81,10 @@ def background(list_of_replicates, input_fragment_value, unlabeled_fragment_valu
         for each_replicate in replicate_group:
             noise = background_noise(unlabeled_fragment_value.data[each_replicate], na, parent_atoms,
                                      parent_label, daughter_atoms, daughter_label)
-            background = background_subtraction(input_fragment_value.data[each_replicate], noise)
+            try:
+                background = background_subtraction(input_fragment_value.data[each_replicate], noise)
+            except:
+                background = background_subtraction(0, noise)
             background_list.append(background)
         background_value = max(background_list)
         for each_replicate in replicate_group:


### PR DESCRIPTION
When certain fragments of a sample don't have peaks Multiquant
outputs 0 as intensity value but El Maven just doesn't output
anything. The code show key error as of now when this happens.
Instead of raising key error, treating the value as 0 because
no value is equivalent to 0.